### PR TITLE
set label color to blue

### DIFF
--- a/extension/tamper.css
+++ b/extension/tamper.css
@@ -25,7 +25,7 @@ body {
 }
 
 h1 {
-  color: #666;
+  color: #999;
   font-family: arial;
 }
 

--- a/extension/tamper.css
+++ b/extension/tamper.css
@@ -10,6 +10,7 @@ body {
     tab-size: 4;
     -webkit-user-select: none;
     color: #222;
+    background-color: #222;
 }
 
 #applink {
@@ -31,7 +32,7 @@ h1 {
 label {
   display: block;
   padding: 5px 0;
-  color: blue;
+  color: white;
 }
 label > input[type="checkbox"] {
   width: 13px;

--- a/extension/tamper.css
+++ b/extension/tamper.css
@@ -31,6 +31,7 @@ h1 {
 label {
   display: block;
   padding: 5px 0;
+  color: blue;
 }
 label > input[type="checkbox"] {
   width: 13px;


### PR DESCRIPTION
Per the following issue:

https://github.com/google/tamperchrome/issues/3

This makes the extension usable with devtools dark theme by setting the label color to blue.