### PR TITLE
rename chromeOptions to goog:

### DIFF
--- a/v2/ui/e2e/protractor.conf.js
+++ b/v2/ui/e2e/protractor.conf.js
@@ -10,12 +10,12 @@ exports.config = {
   ],
   capabilities: {
     'browserName': 'chrome',
-    'chromeOptions': {
+    'goog:chromeOptions': {
       'args': [
-        '--headless',
-        '--no-sandbox',
-        '--disable-gpu',
-        '--disable-dev-shm-usage'
+        'headless',
+        'no-sandbox',
+        'disable-gpu',
+        'disable-dev-shm-usage'
       ]
     }
   },


### PR DESCRIPTION
Depending on the version of selenium installed, `chromeOptions` might be ignored when not prefixed.